### PR TITLE
Added resolvePlaceholders

### DIFF
--- a/src/main/groovy/grails/plugin/externalconfig/ExternalConfigRunListener.groovy
+++ b/src/main/groovy/grails/plugin/externalconfig/ExternalConfigRunListener.groovy
@@ -22,12 +22,12 @@ class ExternalConfigRunListener implements SpringApplicationRunListener {
 	private Logger log = LoggerFactory.getLogger('grails.plugin.externalconfig.ExternalConfig')
 
 	public ExternalConfigRunListener(SpringApplication application, String[] args) { }
-
+	
 	@Override
 	void environmentPrepared(ConfigurableEnvironment environment) {
 		List locations = environment.getProperty('grails.config.locations', ArrayList, [])
 		String encoding = environment.getProperty('grails.config.encoding', String, 'UTF-8')
-
+		
 		for (location in locations) {
 			MapPropertySource propertySource = null
 			if (location instanceof Class) {
@@ -39,10 +39,10 @@ class ExternalConfigRunListener implements SpringApplicationRunListener {
 				if (userHome && finalLocation.startsWith('~/')) {
 					finalLocation = "file:${userHome}${finalLocation[1..-1]}"
 				}
+				finalLocation = environment.resolvePlaceholders(finalLocation) 
+				
 				Resource resource = defaultResourceLoader.getResource(finalLocation)
 				if (resource.exists()) {
-					println "resource exists: $resource.filename"
-
 					if (finalLocation.endsWith('.groovy')) {
 						propertySource = loadGroovyConfig(resource, encoding)
 					} else if (finalLocation.endsWith('.yml')) {

--- a/src/test/groovy/grails/plugin/externalconfig/ExternalConfigSpec.groovy
+++ b/src/test/groovy/grails/plugin/externalconfig/ExternalConfigSpec.groovy
@@ -81,6 +81,32 @@ class ExternalConfigSpec extends Specification {
         file.delete()
     }
 
+    def "when getting config with file in system property user.home"() {
+        given: "The home directory of the user"
+        def dir = new File("${System.getProperty('user.home')}/.grails")
+        dir.mkdirs()
+
+        and: "a new external configuration file"
+        def file = new File(dir, 'external-config-temp-config.groovy')
+        file.text = """\
+            config.value = 'expected-value'
+            nested { config { value = 'nested-value' } }
+            """.stripIndent()
+
+        and:
+        addToEnvironment('grails.config.locations': ['file:${user.home}/.grails/external-config-temp-config.groovy'])
+
+        when:
+        listener.environmentPrepared(environment)
+
+        then:
+        getConfigProperty('config.value') == 'expected-value'
+        getConfigProperty('nested.config.value') == 'nested-value'
+
+        cleanup:
+        file.delete()
+    }
+
     def "when getting config with file in specific folder"() {
         given:
         def file= File.createTempFile("other-external-config-temp-config",'.groovy')
@@ -90,7 +116,7 @@ class ExternalConfigSpec extends Specification {
             """.stripIndent()
 
         and:
-        addToEnvironment('grails.config.locations': ["file://${file.absolutePath}"])
+        addToEnvironment('grails.config.locations': ["file:${file.absolutePath}"])
 
         when:
        listener.environmentPrepared(environment)


### PR DESCRIPTION
Added resolvePlaceholders on each location so you can use systemproperties in the external locations in yml.

 For example
 grails:
    config:
        locations:
            - '${catalina.base}/conf/myapp-config.yml'