### PR TITLE
Adding scripts to convert yml to groovy config and vice versa.

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ For `.groovy` and `.yml` files the `environments` blocks in the config file are 
 
 Scripts
 -----
-This plugin also include two scripts, one for converting yml config, to groovy config,
+This plugin also includes two scripts, one for converting yml config, to groovy config,
 and one for converting groovy config to yml config. These scripts are not guaranteed to be 
 perfect, but you should report any edge cases for the yml to groovy config here:
 https://github.com/virtualdogbert/GroovyConfigWriter/issues

--- a/README.md
+++ b/README.md
@@ -94,5 +94,16 @@ The plugin will skip configuration files that are not found.
 
 For `.groovy` and `.yml` files the `environments` blocks in the config file are interpreted the same way, as in `application.yml` or `application.groovy`.
 
+Scripts
+-----
+This plugin also include two scripts, one for converting yml config, to groovy config,
+and one for converting groovy config to yml config. These scripts are not guaranteed to be 
+perfect, but you should report any edge cases for the yml to groovy config here:
+https://github.com/virtualdogbert/GroovyConfigWriter/issues
 
+Sample usage:
+```
+grails yml-to-groovy-config [ymlFile] [optional outputFile]
+grails groovy-to-yml-config [ymlFile] [optional outputFile]
+```
 

--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,9 @@ dependencyManagement {
 }
 
 dependencies {
+    compile 'com.virtualdogbert:GroovyConfigWriter:0.1'
+    compile 'org.yaml:snakeyaml:1.18'
+
     provided "org.springframework.boot:spring-boot-starter-logging"
     provided "org.springframework.boot:spring-boot-autoconfigure"
     provided "org.grails:grails-core"
@@ -74,7 +77,7 @@ artifactory {
     publish {
         repository {
             repoKey = 'oss-snapshot-local'
-            username = System.getenv("BINTRAY_USER") ?: project.findProperty('bintrayUser') 
+            username = System.getenv("BINTRAY_USER") ?: project.findProperty('bintrayUser')
             password = System.getenv("BINTRAY_KEY") ?: project.findProperty('bintrayKey')
         }
         defaults {

--- a/src/main/scripts/groovy-to-yml-config.groovy
+++ b/src/main/scripts/groovy-to-yml-config.groovy
@@ -1,0 +1,44 @@
+/**
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+import org.yaml.snakeyaml.Yaml
+
+description("Converts a yml config, to a groovy config") {
+    usage "groovy-to-yml-config [ymlFile] [optional outputFile]"
+    argument name: 'groovy', description: 'The groovy input file.'
+    argument name: 'outputFile', description: 'The optional output file. If none is provided, then the output will go to System.out.', required: false
+}
+
+String groovyFile = args[0]
+String outputFile = args[1]
+
+File configFile = new File(groovyFile)
+ConfigSlurper slurper = new ConfigSlurper()
+def config = slurper.parse(configFile.toURL())
+
+Writer configWriter
+
+if(outputFile) {
+    configWriter = new FileWriter(outputFile)
+} else {
+    configWriter = System.out.newPrintWriter()
+}
+
+Yaml yaml = new Yaml()
+
+yaml.dump(config, configWriter)

--- a/src/main/scripts/yml-to-groovy-config.groovy
+++ b/src/main/scripts/yml-to-groovy-config.groovy
@@ -1,0 +1,49 @@
+/**
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+import com.virtualdogbert.GroovyConfigWriter
+import org.yaml.snakeyaml.Yaml
+
+description("Converts a yml config, to a groovy config") {
+    usage "yml-to-groovy-config [ymlFile] [optional outputFile]"
+    argument name: 'ymlFile', description: 'The yml input file.'
+    argument name: 'outputFile', description: 'The optional output file. If none is provided, then the output will go to System.out.', required: false
+}
+
+String ymlFile = args[0]
+String outputFile = args[1]
+
+File config = new File(ymlFile)
+String configText = config.newDataInputStream().getText()
+List<String> docs = configText.split('---\n')
+GroovyConfigWriter configWriter
+
+if(outputFile) {
+    configWriter = new GroovyConfigWriter(outputFile)
+} else {
+    configWriter = new GroovyConfigWriter()
+}
+
+Yaml yaml = new Yaml()
+
+docs.findResults {
+    configWriter.writeToGroovy(yaml.load(it))
+}
+
+configWriter.close()


### PR DESCRIPTION
So I just released a GroovyConfigWriter library, for the purpose of making these scripts available. I thought it would be a little much to make my own plugin just for the scripts, and they seem to fit in with your plugin. 

If there are any changes you would like me to make before merging let me know. Just while typing this I found a typo in my documentation.  The library itself is not perfect, and I'm sure I'll go through some iterations, but I think the best way to get it in front of people to find the edge canse would be to include it in your plugin.

Tell me what you think. Thanks