### PR TITLE
Updating groovy config writer so that it can be used under java  7.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,7 +51,7 @@ dependencies {
     provided "org.springframework.boot:spring-boot-starter-tomcat"
     testCompile "org.grails:grails-plugin-testing"
 
-    runtime 'com.virtualdogbert:GroovyConfigWriter:0.1'
+    runtime 'com.virtualdogbert:GroovyConfigWriter:0.2'
     runtime 'org.yaml:snakeyaml:1.18'
 
 }


### PR DESCRIPTION
Updating groovy config writer so that it can be used under java  7.