### PR TITLE
Method to add the external configuration to classpath when running locally without including it in the war file for production

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,14 @@ The plugin will skip configuration files that are not found.
 
 For `.groovy` and `.yml` files the `environments` blocks in the config file are interpreted the same way, as in `application.yml` or `application.groovy`.
 
+**Getting configuration from another folder than /conf on classpath without moving it with Gradle script**
+
+If you wish to make your Grails application pull external configuration from classpath when running locally, but you do not wish to get it packed into the assembled war file (i.e. place the external configuration file in e.g. /external-config instead of /conf), then you can include the external configuration file to the classpath by adding the following line to build.gradle:dependencies
+```
+providedCompile files('external-config') // providedCompile to ensure that external config is not included in the war file
+```
+Alternatively, you can make a gradle script to move the external configuration file to your classpath (e.g. /build/classes)
+
 Scripts
 -----
 This plugin also includes two scripts, one for converting yml config, to groovy config,


### PR DESCRIPTION
Just an update to README.md