### PR TITLE
Resolving an issue with separator in Windows.

### DIFF
--- a/src/main/groovy/grails/plugin/externalconfig/ExternalConfigRunListener.groovy
+++ b/src/main/groovy/grails/plugin/externalconfig/ExternalConfigRunListener.groovy
@@ -88,7 +88,7 @@ class ExternalConfigRunListener implements SpringApplicationRunListener {
     // Expands wildcards if any
     List<Object> handleWildcardLocation(String location) {
         if(location.startsWith('file:')) {
-            String locationFileName = location.split(separator)[-1]
+            String locationFileName = location.tokenize(separator)[-1]
             if(locationFileName.contains('*')) {
                 String parentLocation = location - locationFileName
                 try {


### PR DESCRIPTION
Resolving an issue with separator being / in windows. Replaced split with tokenize