### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ __Note__: the wildcards are in the order they are found in the `locations` list,
 
 If you wish to make your Grails application pull external configuration from classpath when running locally, but you do not wish to get it packed into the assembled war file (i.e. place the external configuration file in e.g. /external-config instead of /conf), then you can include the external configuration file to the classpath by adding the following line to build.gradle:dependencies
 ```
-providedCompile files('external-config') // providedCompile to ensure that external config is not included in the war file
+provided files('external-config') // provided to ensure that external config is not included in the war file
 ```
 Alternatively, you can make a gradle script to move the external configuration file to your classpath (e.g. /build/classes)
 


### PR DESCRIPTION
Use "provided" rather than "providedCompile" to ensure that external config is not included in the .war file: https://github.com/grails/grails-core/issues/10728