### PR TITLE
Added [0] before first check to avoid error when yml file is empty, b…

### DIFF
--- a/external-config/src/main/groovy/grails/plugin/externalconfig/ExternalConfigRunListener.groovy
+++ b/external-config/src/main/groovy/grails/plugin/externalconfig/ExternalConfigRunListener.groovy
@@ -146,7 +146,7 @@ class ExternalConfigRunListener implements SpringApplicationRunListener {
 
     private NavigableMapPropertySource loadYamlConfig(Resource resource) {
         log.info("Loading YAML config file {}", resource.URI)
-        NavigableMapPropertySource propertySource = yamlPropertySourceLoader.load(resource.filename, resource, null)?.first() as NavigableMapPropertySource
+        NavigableMapPropertySource propertySource = yamlPropertySourceLoader.load(resource.filename, resource, null)[0]?.first() as NavigableMapPropertySource
         return propertySource
     }
 


### PR DESCRIPTION
Error was being thrown when a yml file was present but completely blank. this cased the loader to return `Collections.emptyList()` which what was causing the error. 

Now I can load a totally blank yml file, and the use case is to be able to shell out blank files as placeholders without content.

Tested in Groovy console as well

Works:
def myList = Collections.emptyList()
println myList[0]?.first()

Fails:
def myList = Collections.emptyList()
println myList?.first()