### PR TITLE
Refactored YAML Loading for blank contents

### DIFF
--- a/external-config/src/main/groovy/grails/plugin/externalconfig/ExternalConfigRunListener.groovy
+++ b/external-config/src/main/groovy/grails/plugin/externalconfig/ExternalConfigRunListener.groovy
@@ -146,7 +146,8 @@ class ExternalConfigRunListener implements SpringApplicationRunListener {
 
     private NavigableMapPropertySource loadYamlConfig(Resource resource) {
         log.info("Loading YAML config file {}", resource.URI)
-        NavigableMapPropertySource propertySource = yamlPropertySourceLoader.load(resource.filename, resource, null)?.first() as NavigableMapPropertySource
+        def yamlProperties = yamlPropertySourceLoader.load(resource.filename, resource, null)
+        NavigableMapPropertySource propertySource = ( yamlProperties ? yamlProperties?.first() : null ) as NavigableMapPropertySource
         return propertySource
     }
 


### PR DESCRIPTION
Updated YAM Loader to be able to parse present, but blank yml files without throwing an exception.

Tested locally, and also passed all test-app tests.

Prior to this, the call with ?.first() on the original line 149 would cause an exception and crash an app.

Please review as I am not entirely familiar with this plugin source and was looking at a very narrow issue.

Any feedback is appreciated ;)