### PR TITLE
Support for Grails 5.3.5 & Snakeyaml 2.2

### DIFF
--- a/.sdkmanrc
+++ b/.sdkmanrc
@@ -1,0 +1,4 @@
+java=8.0.392-librca
+grails=5.3.5
+gradle=7.2
+groovy=3.0.8

--- a/README.md
+++ b/README.md
@@ -9,11 +9,11 @@ It also provides scripts to convert between yml & groovy config.
 ## Versions
 
 | Grails | external-config |
-|--|--|
-| 5.2.x | 3.1.0 |
-| 5.0.x | 3.0.0 |
-| 4.x.x | 2.0.1 |
-| 3.3.x | 1.4.0 |
+|--------|-----------------|
+| 5.3.5  | 3.2.0           |
+| 5.0.x  | 3.0.0           |
+| 4.x.x  | 2.0.1           |
+| 3.3.x  | 1.4.0           |
 
 ## Creator and contributors
 
@@ -38,7 +38,7 @@ Add dependency to your `build.gradle`:
 
 ```groovy
 dependencies {
-    compile 'dk.glasius:external-config:3.0.0' // or latest version
+    compile 'dk.glasius:external-config:3.2.0' // or latest version
 }
 ```
 

--- a/external-config/build.gradle
+++ b/external-config/build.gradle
@@ -9,7 +9,6 @@ dependencies {
     implementation(platform("org.grails:grails-bom:$grailsVersion"))
 
     implementation "org.grails:grails-core"
-    implementation 'org.codehaus.groovy:groovy-yaml:3.0.8'
 
     implementation "io.micronaut:micronaut-core"
     implementation "io.micronaut:micronaut-inject"
@@ -17,7 +16,7 @@ dependencies {
     testImplementation "org.grails:grails-testing-support"
 
     runtimeOnly 'com.virtualdogbert:GroovyConfigWriter:1.1'
-    runtimeOnly 'org.yaml:snakeyaml:1.30'
+    runtimeOnly 'org.yaml:snakeyaml:2.2'
 }
 
 tasks.withType(Test) {

--- a/external-config/src/main/groovy/grails/plugin/externalconfig/ExternalConfigRunListener.groovy
+++ b/external-config/src/main/groovy/grails/plugin/externalconfig/ExternalConfigRunListener.groovy
@@ -3,15 +3,12 @@ package grails.plugin.externalconfig
 import grails.util.Environment
 import groovy.transform.CompileStatic
 import groovy.util.logging.Slf4j
-import groovy.yaml.YamlSlurper
 import org.grails.config.PropertySourcesConfig
 import org.grails.config.yaml.YamlPropertySourceLoader
-import org.grails.core.cfg.GroovyConfigPropertySourceLoader
 import org.springframework.boot.ConfigurableBootstrapContext
 import org.springframework.boot.SpringApplication
 import org.springframework.boot.SpringApplicationRunListener
 import org.springframework.boot.env.PropertiesPropertySourceLoader
-import org.springframework.context.ConfigurableApplicationContext
 import org.springframework.core.env.ConfigurableEnvironment
 import org.springframework.core.env.MapPropertySource
 import org.springframework.core.env.PropertySource
@@ -30,7 +27,7 @@ class ExternalConfigRunListener implements SpringApplicationRunListener {
     private ResourceLoader defaultResourceLoader = new DefaultResourceLoader()
     private YamlPropertySourceLoader yamlPropertySourceLoader = new YamlPropertySourceLoader()
     private PropertiesPropertySourceLoader propertiesPropertySourceLoader = new PropertiesPropertySourceLoader()
-    
+
     private String userHome = System.properties.getProperty('user.home')
     private String separator = System.properties.getProperty('file.separator')
 

--- a/external-config/src/test/groovy/grails/plugin/externalconfig/ExternalConfigSpec.groovy
+++ b/external-config/src/test/groovy/grails/plugin/externalconfig/ExternalConfigSpec.groovy
@@ -5,7 +5,6 @@ import org.grails.config.NavigableMap
 import org.grails.config.NavigableMapPropertySource
 import org.grails.testing.GrailsUnitTest
 import org.springframework.core.env.ConfigurableEnvironment
-import org.springframework.core.env.MapPropertySource
 import spock.lang.Issue
 import spock.lang.Specification
 import spock.lang.Unroll

--- a/external-config/src/test/groovy/grails/plugin/externalconfig/MergedConfigSpec.groovy
+++ b/external-config/src/test/groovy/grails/plugin/externalconfig/MergedConfigSpec.groovy
@@ -6,7 +6,6 @@ import org.grails.config.NavigableMapPropertySource
 import org.grails.testing.GrailsUnitTest
 import org.springframework.core.env.ConfigurableEnvironment
 import spock.lang.Specification
-import spock.lang.Unroll
 
 class MergedConfigSpec extends Specification implements GrailsUnitTest {
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,8 +1,8 @@
 #Thu, 01 Sep 2022 14:38:14 +0000
-grailsVersion=5.2.3
+grailsVersion=5.3.5
 grailsGradlePluginVersion=5.2.3
 groovyVersion=3.0.11
-version=3.1.2-SNAPSHOT
+version=3.2.0-SNAPSHOT
 org.gradle.daemon=true
 org.gradle.parallel=true
 org.gradle.jvmargs=-Dfile.encoding\=UTF-8 -Xmx1024M

--- a/gradlew
+++ b/gradlew
@@ -82,6 +82,7 @@ esac
 
 CLASSPATH=$APP_HOME/gradle/wrapper/gradle-wrapper.jar
 
+
 # Determine the Java command to use to start the JVM.
 if [ -n "$JAVA_HOME" ] ; then
     if [ -x "$JAVA_HOME/jre/sh/java" ] ; then
@@ -129,6 +130,7 @@ fi
 if [ "$cygwin" = "true" -o "$msys" = "true" ] ; then
     APP_HOME=`cygpath --path --mixed "$APP_HOME"`
     CLASSPATH=`cygpath --path --mixed "$CLASSPATH"`
+
     JAVACMD=`cygpath --unix "$JAVACMD"`
 
     # We build the pattern for arguments to be converted via cygpath
@@ -154,19 +156,19 @@ if [ "$cygwin" = "true" -o "$msys" = "true" ] ; then
         else
             eval `echo args$i`="\"$arg\""
         fi
-        i=$((i+1))
+        i=`expr $i + 1`
     done
     case $i in
-        (0) set -- ;;
-        (1) set -- "$args0" ;;
-        (2) set -- "$args0" "$args1" ;;
-        (3) set -- "$args0" "$args1" "$args2" ;;
-        (4) set -- "$args0" "$args1" "$args2" "$args3" ;;
-        (5) set -- "$args0" "$args1" "$args2" "$args3" "$args4" ;;
-        (6) set -- "$args0" "$args1" "$args2" "$args3" "$args4" "$args5" ;;
-        (7) set -- "$args0" "$args1" "$args2" "$args3" "$args4" "$args5" "$args6" ;;
-        (8) set -- "$args0" "$args1" "$args2" "$args3" "$args4" "$args5" "$args6" "$args7" ;;
-        (9) set -- "$args0" "$args1" "$args2" "$args3" "$args4" "$args5" "$args6" "$args7" "$args8" ;;
+        0) set -- ;;
+        1) set -- "$args0" ;;
+        2) set -- "$args0" "$args1" ;;
+        3) set -- "$args0" "$args1" "$args2" ;;
+        4) set -- "$args0" "$args1" "$args2" "$args3" ;;
+        5) set -- "$args0" "$args1" "$args2" "$args3" "$args4" ;;
+        6) set -- "$args0" "$args1" "$args2" "$args3" "$args4" "$args5" ;;
+        7) set -- "$args0" "$args1" "$args2" "$args3" "$args4" "$args5" "$args6" ;;
+        8) set -- "$args0" "$args1" "$args2" "$args3" "$args4" "$args5" "$args6" "$args7" ;;
+        9) set -- "$args0" "$args1" "$args2" "$args3" "$args4" "$args5" "$args6" "$args7" "$args8" ;;
     esac
 fi
 
@@ -175,14 +177,9 @@ save () {
     for i do printf %s\\n "$i" | sed "s/'/'\\\\''/g;1s/^/'/;\$s/\$/' \\\\/" ; done
     echo " "
 }
-APP_ARGS=$(save "$@")
+APP_ARGS=`save "$@"`
 
 # Collect all arguments for the java command, following the shell quoting and substitution rules
 eval set -- $DEFAULT_JVM_OPTS $JAVA_OPTS $GRADLE_OPTS "\"-Dorg.gradle.appname=$APP_BASE_NAME\"" -classpath "\"$CLASSPATH\"" org.gradle.wrapper.GradleWrapperMain "$APP_ARGS"
-
-# by default we should be in the correct project dir, but when run from Finder on Mac, the cwd is wrong
-if [ "$(uname)" = "Darwin" ] && [ "$HOME" = "$PWD" ]; then
-  cd "$(dirname "$0")"
-fi
 
 exec "$JAVACMD" "$@"

--- a/gradlew.bat
+++ b/gradlew.bat
@@ -29,6 +29,9 @@ if "%DIRNAME%" == "" set DIRNAME=.
 set APP_BASE_NAME=%~n0
 set APP_HOME=%DIRNAME%
 
+@rem Resolve any "." and ".." in APP_HOME to make it shorter.
+for %%i in ("%APP_HOME%") do set APP_HOME=%%~fi
+
 @rem Add default JVM options here. You can also use JAVA_OPTS and GRADLE_OPTS to pass JVM options to this script.
 set DEFAULT_JVM_OPTS="-Xmx64m" "-Xms64m"
 
@@ -37,7 +40,7 @@ if defined JAVA_HOME goto findJavaFromJavaHome
 
 set JAVA_EXE=java.exe
 %JAVA_EXE% -version >NUL 2>&1
-if "%ERRORLEVEL%" == "0" goto init
+if "%ERRORLEVEL%" == "0" goto execute
 
 echo.
 echo ERROR: JAVA_HOME is not set and no 'java' command could be found in your PATH.
@@ -51,7 +54,7 @@ goto fail
 set JAVA_HOME=%JAVA_HOME:"=%
 set JAVA_EXE=%JAVA_HOME%/bin/java.exe
 
-if exist "%JAVA_EXE%" goto init
+if exist "%JAVA_EXE%" goto execute
 
 echo.
 echo ERROR: JAVA_HOME is set to an invalid directory: %JAVA_HOME%
@@ -61,28 +64,14 @@ echo location of your Java installation.
 
 goto fail
 
-:init
-@rem Get command-line arguments, handling Windows variants
-
-if not "%OS%" == "Windows_NT" goto win9xME_args
-
-:win9xME_args
-@rem Slurp the command line arguments.
-set CMD_LINE_ARGS=
-set _SKIP=2
-
-:win9xME_args_slurp
-if "x%~1" == "x" goto execute
-
-set CMD_LINE_ARGS=%*
-
 :execute
 @rem Setup the command line
 
 set CLASSPATH=%APP_HOME%\gradle\wrapper\gradle-wrapper.jar
 
+
 @rem Execute Gradle
-"%JAVA_EXE%" %DEFAULT_JVM_OPTS% %JAVA_OPTS% %GRADLE_OPTS% "-Dorg.gradle.appname=%APP_BASE_NAME%" -classpath "%CLASSPATH%" org.gradle.wrapper.GradleWrapperMain %CMD_LINE_ARGS%
+"%JAVA_EXE%" %DEFAULT_JVM_OPTS% %JAVA_OPTS% %GRADLE_OPTS% "-Dorg.gradle.appname=%APP_BASE_NAME%" -classpath "%CLASSPATH%" org.gradle.wrapper.GradleWrapperMain %*
 
 :end
 @rem End local scope for the variables with windows NT shell


### PR DESCRIPTION
Grails 5.3.5 ships with Snakeyaml 2.2 instead of 1.3.  This PR:

* Upgrades this plugin to Grails 5.3.5
* Removes the groovy yaml library since it was not being used & that library depends on Snakeyaml 1.3

`gradlew check` shows all tests passing 

I incremented the version to 3.2.0 to signify a major API change (Snakeyaml 2.2 and 1.3 have different constructor args / can be incompatible).